### PR TITLE
[FIX][#41] Fix uncorrect work dispatch method

### DIFF
--- a/lib/workingqueue/dispatcher.go
+++ b/lib/workingqueue/dispatcher.go
@@ -72,13 +72,11 @@ func (d *dispatcher) dispatch() {
 				jobcClosed = true
 			} else {
 				// a job request has been received
-				go func() {
-					// try to obtain a worker job channel that is available.
-					// this will block until a worker is idle
-					workerJobQueue := <-d.workerPool
-					// dispatch the job
-					workerJobQueue <- job
-				}()
+				// try to obtain a worker job channel that is available.
+				// this will block until a worker is idle
+				workerJobQueue := <-d.workerPool
+				// dispatch the job
+				workerJobQueue <- job
 			}
 		case <-d.quit:
 			for _, worker := range d.workers {


### PR DESCRIPTION
Fix dispatch method in order to prevent resource allocation if all the worker are already busy
